### PR TITLE
fix typo `fulll` -> `full` in markdown frontmatter

### DIFF
--- a/content/speakers/AJ.md
+++ b/content/speakers/AJ.md
@@ -4,7 +4,7 @@ type: speaker
 sortOrder: 40
 active: true
 title: AJ
-fulllName: Alok Jain
+fullName: Alok Jain
 jobTitle: Director of Industry Strategy
 company: 3Pillar Global
 description: >-

--- a/content/speakers/DeWolf.md
+++ b/content/speakers/DeWolf.md
@@ -4,7 +4,7 @@ type: speaker
 sortOrder: 1
 active: true
 title: DeWolf
-fulllName: David DeWolf
+fullName: David DeWolf
 jobTitle: Chief Executive Officer
 company: 3Pillar Global
 description: >-

--- a/content/speakers/Kloepping.md
+++ b/content/speakers/Kloepping.md
@@ -4,7 +4,7 @@ type: speaker
 title: Kloepping
 sortOrder: 30
 active: true
-fulllName: Lindsay Kloepping
+fullName: Lindsay Kloepping
 jobTitle: Senior Product Manager
 company: 3Pillar Global
 description: >-

--- a/content/speakers/Rivers.md
+++ b/content/speakers/Rivers.md
@@ -4,7 +4,7 @@ type: speaker
 sortOrder: 10
 active: true
 title: Rivers
-fulllName: Jonathan Rivers
+fullName: Jonathan Rivers
 jobTitle: Chief Technology Officer
 company: 3Pillar Global
 description: >-

--- a/content/workshops/Change.md
+++ b/content/workshops/Change.md
@@ -4,7 +4,7 @@ type: workshop
 sortOrder: 50
 active: true
 title: Change
-fulllTitle: Excel at Change
+fullTitle: Excel at Change
 time: 1:15 PM
 description: >-
   As we'll see during the previous hour, knowing how and when to respond to

--- a/content/workshops/Lunch.md
+++ b/content/workshops/Lunch.md
@@ -4,7 +4,7 @@ type: workshop
 sortOrder: 30
 active: true
 title: Lunch
-fulllTitle: Lunch Break
+fullTitle: Lunch Break
 time: 11:30 AM
 description: >-
   This workshop is known for lively discussion and networking. Connect with

--- a/content/workshops/Networking.md
+++ b/content/workshops/Networking.md
@@ -4,7 +4,7 @@ type: workshop
 sortOrder: 70
 active: true
 title: Networking
-fulllTitle: Happy Hour & Networking
+fullTitle: Happy Hour & Networking
 time: 3:00 - 4:15 PM
 description: >-
   After intense focus on building high-performing teams and high-performance

--- a/content/workshops/Outcomes.md
+++ b/content/workshops/Outcomes.md
@@ -4,7 +4,7 @@ type: workshop
 sortOrder: 20
 active: true
 title: Outcomes
-fulllTitle: Building for Outcomes
+fullTitle: Building for Outcomes
 time: 9:40 AM
 description: >-
   We don't just want to write code, we want to help businesses thrive and grow.

--- a/content/workshops/Overview.md
+++ b/content/workshops/Overview.md
@@ -4,7 +4,7 @@ type: workshop
 sortOrder: 10
 active: true
 title: Overview
-fulllTitle: Why Product Matters & Product Mindset Overview
+fullTitle: Why Product Matters & Product Mindset Overview
 time: 9:15 AM
 description: >-
   We are all trying to create software products customers want but we're often

--- a/content/workshops/Registration.md
+++ b/content/workshops/Registration.md
@@ -4,7 +4,7 @@ type: workshop
 sortOrder: 1
 active: true
 title: Registration
-fulllTitle: Registration & Breakfast
+fullTitle: Registration & Breakfast
 time: 8:30 AM
 description: >-
   Welcome to the Product Mindset Workshop! Come early to register, pick up your

--- a/content/workshops/Summary.md
+++ b/content/workshops/Summary.md
@@ -4,7 +4,7 @@ type: workshop
 sortOrder: 60
 active: true
 title: Summary
-fulllTitle: Summary & Panel Discussion
+fullTitle: Summary & Panel Discussion
 time: 2:35 PM
 description: >-
   To wrap things up, we'll bring it back to center and leave you with some

--- a/content/workshops/Value.md
+++ b/content/workshops/Value.md
@@ -4,7 +4,7 @@ type: workshop
 sortOrder: 40
 active: true
 title: Value
-fulllTitle: Minimize Time to Value
+fullTitle: Minimize Time to Value
 time: 12:00 PM
 description: >-
   If you're not putting something tangible into stakeholders' - or better yet,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "gatsby-starter-typescript-plus",
-  "description": "Gatsby TypeScript starter plus",
+  "name": "product-mindset-site",
+  "description": "3Pillar Global Product Mindset Site",
   "version": "1.0.0",
   "author": "Derek Tiffany <derek.tiffany+product-mindset@3pillarglobal.com>",
   "repository": {

--- a/src/graphql-types.d.ts
+++ b/src/graphql-types.d.ts
@@ -101,7 +101,6 @@ export interface packageJson_2 {
   description?: string | null;
   version?: string | null;
   main?: string | null;
-  author?: string | null;
   license?: string | null;
   dependencies?: dependencies_2[] | null;
   devDependencies?: devDependencies_2[] | null;
@@ -355,12 +354,12 @@ export interface frontmatter_2 {
   type?: string | null;
   sortOrder?: number | null;
   active?: boolean | null;
-  fulllName?: string | null;
+  fullName?: string | null;
   jobTitle?: string | null;
   company?: string | null;
   description?: string | null;
   image?: string | null;
-  fulllTitle?: string | null;
+  fullTitle?: string | null;
   time?: string | null;
 }
 
@@ -771,7 +770,6 @@ export interface sitePageConnectionPluginCreatorPackageJsonInputObject {
   description?: sitePageConnectionPluginCreatorPackageJsonDescriptionQueryString | null;
   version?: sitePageConnectionPluginCreatorPackageJsonVersionQueryString | null;
   main?: sitePageConnectionPluginCreatorPackageJsonMainQueryString | null;
-  author?: sitePageConnectionPluginCreatorPackageJsonAuthorQueryString | null;
   license?: sitePageConnectionPluginCreatorPackageJsonLicenseQueryString | null;
   dependencies?: sitePageConnectionPluginCreatorPackageJsonDependenciesQueryList | null;
   devDependencies?: sitePageConnectionPluginCreatorPackageJsonDevDependenciesQueryList | null;
@@ -801,13 +799,6 @@ export interface sitePageConnectionPluginCreatorPackageJsonVersionQueryString {
 }
 
 export interface sitePageConnectionPluginCreatorPackageJsonMainQueryString {
-  eq?: string | null;
-  ne?: string | null;
-  regex?: string | null;
-  glob?: string | null;
-}
-
-export interface sitePageConnectionPluginCreatorPackageJsonAuthorQueryString {
   eq?: string | null;
   ne?: string | null;
   regex?: string | null;
@@ -1102,7 +1093,6 @@ export interface sitePluginConnectionPackageJsonInputObject_2 {
   description?: sitePluginConnectionPackageJsonDescriptionQueryString_2 | null;
   version?: sitePluginConnectionPackageJsonVersionQueryString_2 | null;
   main?: sitePluginConnectionPackageJsonMainQueryString_2 | null;
-  author?: sitePluginConnectionPackageJsonAuthorQueryString_2 | null;
   license?: sitePluginConnectionPackageJsonLicenseQueryString_2 | null;
   dependencies?: sitePluginConnectionPackageJsonDependenciesQueryList_2 | null;
   devDependencies?: sitePluginConnectionPackageJsonDevDependenciesQueryList_2 | null;
@@ -1132,13 +1122,6 @@ export interface sitePluginConnectionPackageJsonVersionQueryString_2 {
 }
 
 export interface sitePluginConnectionPackageJsonMainQueryString_2 {
-  eq?: string | null;
-  ne?: string | null;
-  regex?: string | null;
-  glob?: string | null;
-}
-
-export interface sitePluginConnectionPackageJsonAuthorQueryString_2 {
   eq?: string | null;
   ne?: string | null;
   regex?: string | null;
@@ -2348,12 +2331,12 @@ export interface markdownRemarkConnectionFrontmatterInputObject_2 {
   type?: markdownRemarkConnectionFrontmatterTypeQueryString_2 | null;
   sortOrder?: markdownRemarkConnectionFrontmatterSortOrderQueryInteger_2 | null;
   active?: markdownRemarkConnectionFrontmatterActiveQueryBoolean_2 | null;
-  fulllName?: markdownRemarkConnectionFrontmatterFulllNameQueryString_2 | null;
+  fullName?: markdownRemarkConnectionFrontmatterFullNameQueryString_2 | null;
   jobTitle?: markdownRemarkConnectionFrontmatterJobTitleQueryString_2 | null;
   company?: markdownRemarkConnectionFrontmatterCompanyQueryString_2 | null;
   description?: markdownRemarkConnectionFrontmatterDescriptionQueryString_2 | null;
   image?: markdownRemarkConnectionFrontmatterImageQueryString_2 | null;
-  fulllTitle?: markdownRemarkConnectionFrontmatterFulllTitleQueryString_2 | null;
+  fullTitle?: markdownRemarkConnectionFrontmatterFullTitleQueryString_2 | null;
   time?: markdownRemarkConnectionFrontmatterTimeQueryString_2 | null;
 }
 
@@ -2447,7 +2430,7 @@ export interface markdownRemarkConnectionFrontmatterActiveQueryBoolean_2 {
   ne?: boolean | null;
 }
 
-export interface markdownRemarkConnectionFrontmatterFulllNameQueryString_2 {
+export interface markdownRemarkConnectionFrontmatterFullNameQueryString_2 {
   eq?: string | null;
   ne?: string | null;
   regex?: string | null;
@@ -2482,7 +2465,7 @@ export interface markdownRemarkConnectionFrontmatterImageQueryString_2 {
   glob?: string | null;
 }
 
-export interface markdownRemarkConnectionFrontmatterFulllTitleQueryString_2 {
+export interface markdownRemarkConnectionFrontmatterFullTitleQueryString_2 {
   eq?: string | null;
   ne?: string | null;
   regex?: string | null;
@@ -2765,7 +2748,6 @@ export interface sitePagePluginCreatorPackageJsonInputObject {
   description?: sitePagePluginCreatorPackageJsonDescriptionQueryString | null;
   version?: sitePagePluginCreatorPackageJsonVersionQueryString | null;
   main?: sitePagePluginCreatorPackageJsonMainQueryString | null;
-  author?: sitePagePluginCreatorPackageJsonAuthorQueryString | null;
   license?: sitePagePluginCreatorPackageJsonLicenseQueryString | null;
   dependencies?: sitePagePluginCreatorPackageJsonDependenciesQueryList | null;
   devDependencies?: sitePagePluginCreatorPackageJsonDevDependenciesQueryList | null;
@@ -2795,13 +2777,6 @@ export interface sitePagePluginCreatorPackageJsonVersionQueryString {
 }
 
 export interface sitePagePluginCreatorPackageJsonMainQueryString {
-  eq?: string | null;
-  ne?: string | null;
-  regex?: string | null;
-  glob?: string | null;
-}
-
-export interface sitePagePluginCreatorPackageJsonAuthorQueryString {
   eq?: string | null;
   ne?: string | null;
   regex?: string | null;
@@ -3071,7 +3046,6 @@ export interface sitePluginPackageJsonInputObject_2 {
   description?: sitePluginPackageJsonDescriptionQueryString_2 | null;
   version?: sitePluginPackageJsonVersionQueryString_2 | null;
   main?: sitePluginPackageJsonMainQueryString_2 | null;
-  author?: sitePluginPackageJsonAuthorQueryString_2 | null;
   license?: sitePluginPackageJsonLicenseQueryString_2 | null;
   dependencies?: sitePluginPackageJsonDependenciesQueryList_2 | null;
   devDependencies?: sitePluginPackageJsonDevDependenciesQueryList_2 | null;
@@ -3101,13 +3075,6 @@ export interface sitePluginPackageJsonVersionQueryString_2 {
 }
 
 export interface sitePluginPackageJsonMainQueryString_2 {
-  eq?: string | null;
-  ne?: string | null;
-  regex?: string | null;
-  glob?: string | null;
-}
-
-export interface sitePluginPackageJsonAuthorQueryString_2 {
   eq?: string | null;
   ne?: string | null;
   regex?: string | null;
@@ -4262,12 +4229,12 @@ export interface markdownRemarkFrontmatterInputObject_2 {
   type?: markdownRemarkFrontmatterTypeQueryString_2 | null;
   sortOrder?: markdownRemarkFrontmatterSortOrderQueryInteger_2 | null;
   active?: markdownRemarkFrontmatterActiveQueryBoolean_2 | null;
-  fulllName?: markdownRemarkFrontmatterFulllNameQueryString_2 | null;
+  fullName?: markdownRemarkFrontmatterFullNameQueryString_2 | null;
   jobTitle?: markdownRemarkFrontmatterJobTitleQueryString_2 | null;
   company?: markdownRemarkFrontmatterCompanyQueryString_2 | null;
   description?: markdownRemarkFrontmatterDescriptionQueryString_2 | null;
   image?: markdownRemarkFrontmatterImageQueryString_2 | null;
-  fulllTitle?: markdownRemarkFrontmatterFulllTitleQueryString_2 | null;
+  fullTitle?: markdownRemarkFrontmatterFullTitleQueryString_2 | null;
   time?: markdownRemarkFrontmatterTimeQueryString_2 | null;
 }
 
@@ -4361,7 +4328,7 @@ export interface markdownRemarkFrontmatterActiveQueryBoolean_2 {
   ne?: boolean | null;
 }
 
-export interface markdownRemarkFrontmatterFulllNameQueryString_2 {
+export interface markdownRemarkFrontmatterFullNameQueryString_2 {
   eq?: string | null;
   ne?: string | null;
   regex?: string | null;
@@ -4396,7 +4363,7 @@ export interface markdownRemarkFrontmatterImageQueryString_2 {
   glob?: string | null;
 }
 
-export interface markdownRemarkFrontmatterFulllTitleQueryString_2 {
+export interface markdownRemarkFrontmatterFullTitleQueryString_2 {
   eq?: string | null;
   ne?: string | null;
   regex?: string | null;
@@ -5604,12 +5571,12 @@ export enum MarkdownRemarkConnectionSortByFieldsEnum {
   frontmatter___type = "frontmatter___type",
   frontmatter___sortOrder = "frontmatter___sortOrder",
   frontmatter___active = "frontmatter___active",
-  frontmatter___fulllName = "frontmatter___fulllName",
+  frontmatter___fullName = "frontmatter___fullName",
   frontmatter___jobTitle = "frontmatter___jobTitle",
   frontmatter___company = "frontmatter___company",
   frontmatter___description = "frontmatter___description",
   frontmatter___image = "frontmatter___image",
-  frontmatter___fulllTitle = "frontmatter___fulllTitle",
+  frontmatter___fullTitle = "frontmatter___fullTitle",
   frontmatter___time = "frontmatter___time",
   excerpt = "excerpt",
   fileAbsolutePath = "fileAbsolutePath",
@@ -5650,12 +5617,12 @@ export enum markdownRemarkDistinctEnum {
   frontmatter___type = "frontmatter___type",
   frontmatter___sortOrder = "frontmatter___sortOrder",
   frontmatter___active = "frontmatter___active",
-  frontmatter___fulllName = "frontmatter___fulllName",
+  frontmatter___fullName = "frontmatter___fullName",
   frontmatter___jobTitle = "frontmatter___jobTitle",
   frontmatter___company = "frontmatter___company",
   frontmatter___description = "frontmatter___description",
   frontmatter___image = "frontmatter___image",
-  frontmatter___fulllTitle = "frontmatter___fulllTitle",
+  frontmatter___fullTitle = "frontmatter___fullTitle",
   frontmatter___time = "frontmatter___time",
   excerpt = "excerpt",
   fileAbsolutePath = "fileAbsolutePath",
@@ -5684,12 +5651,12 @@ export enum markdownRemarkGroupEnum {
   frontmatter___type = "frontmatter___type",
   frontmatter___sortOrder = "frontmatter___sortOrder",
   frontmatter___active = "frontmatter___active",
-  frontmatter___fulllName = "frontmatter___fulllName",
+  frontmatter___fullName = "frontmatter___fullName",
   frontmatter___jobTitle = "frontmatter___jobTitle",
   frontmatter___company = "frontmatter___company",
   frontmatter___description = "frontmatter___description",
   frontmatter___image = "frontmatter___image",
-  frontmatter___fulllTitle = "frontmatter___fulllTitle",
+  frontmatter___fullTitle = "frontmatter___fullTitle",
   frontmatter___time = "frontmatter___time",
   excerpt = "excerpt",
   fileAbsolutePath = "fileAbsolutePath",

--- a/src/templates/workshops-page.tsx
+++ b/src/templates/workshops-page.tsx
@@ -27,7 +27,7 @@ const WorkshopsPageLayout: React.StatelessComponent<WorkshopPageTemplateLayoutPr
                   key={speakerKey}
                   description={speakerEdge.node!.frontmatter!.description!}
                   imageSrc={speakerEdge.node!.frontmatter!.image!}
-                  imageAlt={speakerEdge.node!.frontmatter!.Name!}
+                  imageAlt={speakerEdge.node!.frontmatter!.fullName!}
                 >
                   <p className="title is-4">{speakerEdge.node!.frontmatter!.fullName!}</p>
                   <p className="subtitle is-6">{speakerEdge.node!.frontmatter!.jobTitle!}</p>

--- a/src/templates/workshops-page.tsx
+++ b/src/templates/workshops-page.tsx
@@ -27,9 +27,9 @@ const WorkshopsPageLayout: React.StatelessComponent<WorkshopPageTemplateLayoutPr
                   key={speakerKey}
                   description={speakerEdge.node!.frontmatter!.description!}
                   imageSrc={speakerEdge.node!.frontmatter!.image!}
-                  imageAlt={speakerEdge.node!.frontmatter!.fulllName!}
+                  imageAlt={speakerEdge.node!.frontmatter!.Name!}
                 >
-                  <p className="title is-4">{speakerEdge.node!.frontmatter!.fulllName!}</p>
+                  <p className="title is-4">{speakerEdge.node!.frontmatter!.fullName!}</p>
                   <p className="subtitle is-6">{speakerEdge.node!.frontmatter!.jobTitle!}</p>
                   <p className="subtitle is-6">{speakerEdge.node!.frontmatter!.company!}</p>
                 </CardComponent>
@@ -45,13 +45,13 @@ const WorkshopsPageLayout: React.StatelessComponent<WorkshopPageTemplateLayoutPr
             key={workshopKey}
             description={workshopEdge.node!.frontmatter!.description!}
             imageSrc={workshopEdge.node!.frontmatter!.image!}
-            imageAlt={workshopEdge.node!.frontmatter!.fulllTitle!}
+            imageAlt={workshopEdge.node!.frontmatter!.fullTitle!}
           >
             <p className="subtitle is-6">
               <i className="far fa-clock fa-fw"></i>
               {workshopEdge.node!.frontmatter!.time!}
             </p>
-            <p className="title is-4">{workshopEdge.node!.frontmatter!.fulllTitle!}</p>
+            <p className="title is-4">{workshopEdge.node!.frontmatter!.fullTitle!}</p>
           </CardComponent>
         ))}
       </div>
@@ -68,7 +68,7 @@ export const WorkshopsPageTemplateQuery = graphql`
       edges {
         node {
           frontmatter {
-            fulllName
+            fullName
             jobTitle
             company
             description
@@ -83,7 +83,7 @@ export const WorkshopsPageTemplateQuery = graphql`
       edges {
         node {
           frontmatter {
-            fulllTitle
+            fullTitle
             time
             description
             image


### PR DESCRIPTION
fix typo `fulll` -> `full` in markdown frontmatter for speakers and workshops

Issue #71 